### PR TITLE
ansible-hosts.j2: Removed redundant oozie

### DIFF
--- a/roles/ansible-tdp-common-actions/templates/ansible-hosts.j2
+++ b/roles/ansible-tdp-common-actions/templates/ansible-hosts.j2
@@ -69,7 +69,6 @@ master-02
 [postgresql_client:children]
 hive_s2
 ranger_admin
-oozie_server
 
 [ranger_admin]
 master-02
@@ -78,10 +77,4 @@ master-02
 master-01
 
 [spark_client]
-edge-01
-
-[oozie_server]
-master-01
-
-[oozie_client]
 edge-01


### PR DESCRIPTION
oozie_server and oozie_client groups removed from hosts creation template.