### PR TITLE
Add nessie_server role and playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Please check the main [Ansible TDP Roles](https://github.com/TOSIT-FR/ansible-td
 
 - `airflow`: deploys the Apache Airflow release (Airflow Webserver + Scheduler + Worker)
 - `livy.server`: deploys Apache Livy Server
+- `nessie.server`: deploys Nessie server
 
 ## Example
 
@@ -22,3 +23,4 @@ Please follow the guidelines at [contributing](./docs/contributing.md) and respe
 - [leopaul36](https://github.com/leopaul36)
 - [DanielJohnHarty](https://github.com/DanielJohnHarty)
 - [Nuttymoon](https://github.com/Nuttymoon)
+- [sergkudinov](https://github.com/sergkudinov)

--- a/playbooks/nessie.yml
+++ b/playbooks/nessie.yml
@@ -1,0 +1,5 @@
+---
+- import_playbook: nessie_server_install.yml
+- import_playbook: nessie_ssl-tls_install.yml
+- import_playbook: nessie_server_config.yml
+- import_playbook: nessie_server_start.yml

--- a/playbooks/nessie_server_config.yml
+++ b/playbooks/nessie_server_config.yml
@@ -1,0 +1,10 @@
+---
+- name: Nessie Server Config
+  hosts: nessie_server
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: nessie_server
+    - import_role:
+        name: tosit.tdp_extra.nessie.server
+        tasks_from: config
+    - meta: clear_facts

--- a/playbooks/nessie_server_install.yml
+++ b/playbooks/nessie_server_install.yml
@@ -1,0 +1,10 @@
+---
+- name: Nessie Server Install
+  hosts: nessie_server
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: nessie_server
+    - import_role:
+        name: tosit.tdp_extra.nessie.server
+        tasks_from: install
+    - meta: clear_facts

--- a/playbooks/nessie_server_restart.yml
+++ b/playbooks/nessie_server_restart.yml
@@ -1,0 +1,10 @@
+---
+- name: Nessie Server Restart
+  hosts: nessie_server
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: nessie_server
+    - import_role:
+        name: tosit.tdp_extra.nessie.server
+        tasks_from: restart
+    - meta: clear_facts

--- a/playbooks/nessie_server_start.yml
+++ b/playbooks/nessie_server_start.yml
@@ -1,0 +1,10 @@
+---
+- name: Nessie Server Start
+  hosts: nessie_server
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: nessie_server
+    - import_role:
+        name: tosit.tdp_extra.nessie.server
+        tasks_from: start
+    - meta: clear_facts

--- a/playbooks/nessie_server_stop.yml
+++ b/playbooks/nessie_server_stop.yml
@@ -1,0 +1,10 @@
+---
+- name: Nessie Server Stop
+  hosts: nessie_server
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: nessie_server
+    - import_role:
+        name: tosit.tdp_extra.nessie.server
+        tasks_from: stop
+    - meta: clear_facts

--- a/playbooks/nessie_ssl-tls_install.yml
+++ b/playbooks/nessie_ssl-tls_install.yml
@@ -1,0 +1,10 @@
+---
+- name: SSL-TLS Nessie Server Install
+  hosts: nessie_server
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: nessie_server
+    - import_role:
+        name: tosit.tdp_extra.nessie.server
+        tasks_from: ssl-tls
+    - meta: clear_facts

--- a/roles/ansible-tdp-common-actions/templates/ansible-hosts.j2
+++ b/roles/ansible-tdp-common-actions/templates/ansible-hosts.j2
@@ -110,6 +110,9 @@ livy_server
 [livy_server]
 edge-01
 
+[nessie_server]
+edge-01
+
 [knox]
 edge-01
 

--- a/roles/nessie/README.md
+++ b/roles/nessie/README.md
@@ -1,0 +1,36 @@
+# Ansible Nessie TDP Extra
+
+Deploys [Nessie](https://projectnessie.org/) server to the `nessie_server` Ansible group.
+
+## Prerequisites
+
+- `nessie-quarkus-0.29.0-runner` available in `files`
+- Group `nessie_server` defined in the Ansible inventory
+- Certificate of the CA available as `root.pem` in `files`
+- Certificate files `{{ fqdn }}.key` and `{{ fqdn }}.pem` available in `files`
+
+## Example
+
+The following hosts file and playbook are given as examples.
+
+### Host file
+
+```
+[nessie_server]
+edge-01
+```
+
+### Available Playbooks
+
+- [nessie.yml](../../playbooks/nessie.yml):
+
+  - A-Z deployment of Nessie server
+
+## TODO
+
+- Integrate [Nessie CLI](https://projectnessie.org/tools/cli/)
+
+## References
+
+- [Releases](https://github.com/projectnessie/nessie/releases)
+- [Configuration](https://projectnessie.org/try/configuration/)

--- a/roles/nessie/server/tasks/config.yml
+++ b/roles/nessie/server/tasks/config.yml
@@ -1,0 +1,26 @@
+---
+- name: Check if Nessie Server config exists
+  stat:
+    path: "{{ nessie_server_conf_dir }}/"
+  register: nessie_config
+
+- name: Backup Nessie Server config
+  copy:
+    src: "{{ nessie_server_conf_dir }}/"
+    dest: "{{ nessie_server_conf_dir }}.{{ ansible_date_time.epoch }}"
+    group: "{{ hadoop_group }}"
+    owner: "{{ nessie_user }}"
+    remote_src: yes
+  when: nessie_config.stat.exists
+
+- name: Ensure Nessie Server config dir exists
+  file:
+    path: "{{ nessie_server_conf_dir }}/"
+    state: directory
+
+- name: Template nessie-server.env
+  template:
+    src: nessie-server.env.j2
+    dest: "{{ nessie_server_conf_dir }}/nessie-server.env"
+    owner:
+    mode:

--- a/roles/nessie/server/tasks/install.yml
+++ b/roles/nessie/server/tasks/install.yml
@@ -1,0 +1,34 @@
+---
+- include_role:
+    name: tosit.tdp.utils.user
+  vars:
+    user: "{{ nessie_user }}"
+    group: "{{ hadoop_group }}"
+
+- name: Ensure Nessie root dir exists
+  file:
+    path: "{{ nessie_root_dir }}"
+    state: directory
+
+- name: Upload {{ nessie_dist_file }}
+  copy:
+    src: "files/{{ nessie_dist_file }}"
+    dest: "{{ nessie_root_dir }}"
+    mode: 755
+  diff: no
+
+- name: Ensure Nessie install dir exists
+  file:
+    path: "{{ nessie_install_dir }}"
+    state: directory
+    
+- name: Create symbolic link to Nessie Server
+  file:
+    dest: "{{ nessie_install_dir }}/nessie-server"
+    src: "{{ nessie_root_dir }}/{{ nessie_release }}"
+    state: link
+
+- name: Template Nessie Server service file
+  template:
+    src: nessie-server.service.j2
+    dest: /usr/lib/systemd/system/nessie-server.service

--- a/roles/nessie/server/tasks/restart.yml
+++ b/roles/nessie/server/tasks/restart.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart nessie-server
+  service:
+    name: nessie-server
+    state: restarted

--- a/roles/nessie/server/tasks/ssl-tls.yml
+++ b/roles/nessie/server/tasks/ssl-tls.yml
@@ -1,0 +1,7 @@
+---
+- include_role:
+    name: tosit.tdp.utils.ssl_tls
+    tasks_from: create_keystore
+  vars:
+    keystore_location: "{{ nessie_keystore_location }}"
+    keystore_password: "{{ nessie_keystore_password }}"

--- a/roles/nessie/server/tasks/start.yml
+++ b/roles/nessie/server/tasks/start.yml
@@ -1,0 +1,5 @@
+---
+- name: Start nessie-server
+  service:
+    name: nessie-server
+    state: started

--- a/roles/nessie/server/templates/nessie-server.env.j2
+++ b/roles/nessie/server/templates/nessie-server.env.j2
@@ -1,0 +1,5 @@
+# Refer to configuration documentation - https://projectnessie.org/try/configuration/
+
+{% for name, value in nessie_server_env.items() %}
+{{ name }}={{ value }}
+{% endfor %}

--- a/roles/nessie/server/templates/nessie-server.service.j2
+++ b/roles/nessie/server/templates/nessie-server.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Nessie Server
+
+[Service]
+Type=simple
+User={{ nessie_user }}
+Group={{ hadoop_group }}
+ExecStart={{ nessie_install_dir }}/nessie-server 
+LimitNOFILE=64000
+Restart={{ nessie_restart }}
+EnvironmentFile={{ nessie_server_conf_dir }}/nessie-server.env
+
+[Install]
+WantedBy=multi-user.target

--- a/tdp_lib_dag/nessie.yml
+++ b/tdp_lib_dag/nessie.yml
@@ -1,0 +1,44 @@
+---
+- name: nessie_server_install
+  depends_on: []
+
+- name: nessie_ssl-tls_install
+  depends_on:
+    - nessie_server_install
+
+- name: nessie_server_config
+  depends_on:
+    - nessie_ssl-tls_install
+
+- name: nessie_server_start
+  depends_on:
+    - nessie_server_config
+
+- name: nessie_server_init
+  noop: yes
+  depends_on:
+    - nessie_server_start
+
+- name: nessie_install
+  noop: yes
+  depends_on:
+    - nessie_server_install
+    - nessie_ssl-tls_install
+
+- name: nessie_config
+  noop: yes
+  depends_on:
+    - nessie_install
+    - nessie_server_config
+
+- name: nessie_start
+  noop: yes
+  depends_on:
+    - nessie_config
+    - nessie_server_start
+
+- name: nessie_init
+  noop: yes
+  depends_on:
+    - nessie_start
+    - nessie_server_init

--- a/tdp_vars_defaults/nessie/nessie.yml
+++ b/tdp_vars_defaults/nessie/nessie.yml
@@ -1,0 +1,33 @@
+---
+# Nessie version
+nessie_release: nessie-quarkus-0.29.0-runner
+nessie_dist_file: "{{ nessie_release }}"
+
+# Nessie user and group
+nessie_user: nessie
+hadoop_group: hadoop
+
+# Nessie installation directory
+nessie_root_dir: /opt/tdp
+nessie_install_dir: "{{ nessie_root_dir }}/nessie"
+
+# Nessie configuration directory
+nessie_root_conf_dir: /etc/nessie
+nessie_server_conf_dir: "{{ nessie_root_conf_dir }}/conf.server"
+
+# SSL Keystore and Truststore
+nessie_keystore_location: /etc/ssl/certs/keystore.jks
+nessie_keystore_password: Keystore123!
+
+# Service restart policies
+nessie_restart: "no"
+
+# nessie-server.env
+nessie_server_env:
+  # Refer to configuration documentation - https://projectnessie.org/try/configuration/
+  # Note, Nessie is a Quarkus application, it is configured via properties converted from environment variables,
+  # Follow the conversion rules specified by [MicroProfile Config](https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc#default-configsources). 
+  QUARKUS_HTTP_INSECURE_REQUESTS: redirect
+  QUARKUS_HTTP_SSL_PORT: 19433 # The default SSL port 8443 is most likely already taken by another component
+  QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_FILE: "{{ nessie_keystore_location }}"
+  QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_PASSWORD: "{{ nessie_keystore_password }}"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Fixes #24

#### Additional comments:

I am not sure about installing Nessie server on `edge-01` configured in https://github.com/TOSIT-IO/tdp-collection-extras/blob/master/roles/ansible-tdp-common-actions/templates/ansible-hosts.j2

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/),
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.