### PR TITLE
feature: configure chronyd for VMs

### DIFF
--- a/roles/ansible-tdp-common-actions/tasks/config-chrony-for-vms.yml
+++ b/roles/ansible-tdp-common-actions/tasks/config-chrony-for-vms.yml
@@ -1,0 +1,12 @@
+---
+- name: Configure chrony for VM hibernation/reboot
+  replace:
+    dest: /etc/chrony.conf
+    regexp: '^makestep.*$'
+    replace: 'makestep 1 -1'
+    backup: yes
+
+- name: Restart chronyd
+  service:
+    name: chronyd
+    state: restarted

--- a/roles/ansible-tdp-common-actions/tasks/main.yml
+++ b/roles/ansible-tdp-common-actions/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 - include_tasks: common-deployment-actions.yml
+- include_tasks: config-chrony-for-vms.yml
 - include_tasks: update-hosts-file.yml


### PR DESCRIPTION
# Fixes issue
Fixes Issue [94](https://github.com/TOSIT-IO/tdp-getting-started/issues/94) of tdp-getting-started.

# Additional comments
Configure chronyd to sync 1+ second clock deviations at any time (not limited to just after boot). This fixes clock deviations caused by hibernations of a host machine running VMs.
