### PR TITLE
Add Ranger Kafka plugin install and config

### DIFF
--- a/playbooks/kafka_ranger_config.yml
+++ b/playbooks/kafka_ranger_config.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Kafka Ranger plugin config
+  hosts: kafka_broker
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: kafka_ranger
+    - import_role:
+        name: tosit.tdp_extra.kafka.ranger
+        tasks_from: config
+    - meta: clear_facts

--- a/playbooks/kafka_ranger_init.yml
+++ b/playbooks/kafka_ranger_init.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Kafka Ranger plugin init
+  hosts: kafka_broker
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: kafka_ranger
+    - import_role:
+        name: tosit.tdp_extra.kafka.ranger
+        tasks_from: init
+    - meta: clear_facts

--- a/playbooks/kafka_ranger_install.yml
+++ b/playbooks/kafka_ranger_install.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Kafka Ranger plugin install
+  hosts: kafka_broker
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: kafka_ranger
+    - import_role:
+        name: tosit.tdp_extra.kafka.ranger
+        tasks_from: install
+    - meta: clear_facts

--- a/playbooks/kafka_ranger_ssl-tls_install.yml
+++ b/playbooks/kafka_ranger_ssl-tls_install.yml
@@ -1,0 +1,13 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Kafka Ranger plugin SSL-TLS install
+  hosts: kafka_broker
+  tasks:
+    - tosit.tdp.resolve:
+        node_name: kafka_ranger
+    - import_role:
+        name: tosit.tdp_extra.kafka.ranger
+        tasks_from: ssl-tls
+    - meta: clear_facts

--- a/playbooks/meta/kafka.yml
+++ b/playbooks/meta/kafka.yml
@@ -7,10 +7,14 @@
 - import_playbook: ../kafka_jmx-exporter_config.yml
 - import_playbook: ../kafka_kerberos_install.yml
 - import_playbook: ../kafka_client_config.yml
+- import_playbook: ../kafka_ranger_install.yml
+- import_playbook: ../kafka_ranger_ssl-tls_install.yml
 - import_playbook: ../kafka_ssl-tls_install.yml
 # kafka_install
 - import_playbook: ../kafka_broker_config.yml
+- import_playbook: ../kafka_ranger_config.yml
 # kafka_config
+- import_playbook: ../kafka_ranger_init.yml
 - import_playbook: ../kafka_broker_start.yml
 # kafka_start
 # kafka_init

--- a/roles/ansible-tdp-common-actions/tasks/deploy-ranger-hbase-policy.yml
+++ b/roles/ansible-tdp-common-actions/tasks/deploy-ranger-hbase-policy.yml
@@ -12,7 +12,7 @@
 
 - name: Get policy ids
   vars:
-    hbase_policy_query: "[? name == '{{item.name}}'].id"
+    hbase_policy_query: "[? name == '{{ item.name }}'].id"
   set_fact:
     hbase_policy_id: "{{ jsoncontent.json | community.general.json_query(hbase_policy_query) }}"
 
@@ -27,4 +27,4 @@
     url_password: "{{ ranger_admin_password }}"
     force_basic_auth: yes
     method: POST
-  when: hbase_policy_id == []
+  when: not hbase_policy_id

--- a/roles/ansible-tdp-common-actions/tasks/deploy-ranger-hdfs-policy.yml
+++ b/roles/ansible-tdp-common-actions/tasks/deploy-ranger-hdfs-policy.yml
@@ -12,7 +12,7 @@
 
 - name: Get policy ids
   vars:
-    hdfs_policy_query: "[? name == '{{item.name}}'].id"
+    hdfs_policy_query: "[? name == '{{ item.name }}'].id"
   set_fact:
     hdfs_policy_id: "{{ jsoncontent.json | community.general.json_query(hdfs_policy_query) }}"
 
@@ -27,4 +27,4 @@
     url_password: "{{ ranger_admin_password }}"
     force_basic_auth: yes
     method: POST
-  when: hdfs_policy_id == []
+  when: not hdfs_policy_id

--- a/roles/ansible-tdp-common-actions/tasks/deploy-ranger-kafka-policy.yml
+++ b/roles/ansible-tdp-common-actions/tasks/deploy-ranger-kafka-policy.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Ranger: get policy list"
   uri:
-    url: "{{ ranger_hive_install_properties.POLICY_MGR_URL }}/service/public/v2/api/policy"
+    url: "{{ ranger_kafka_install_properties.POLICY_MGR_URL }}/service/public/v2/api/policy"
     headers:
       Accept: application/json
     url_username: "{{ ranger_admin_user }}"
@@ -12,13 +12,13 @@
 
 - name: Get policy ids
   vars:
-    hive_policy_query: "[? name == '{{ item.name }}'].id"
+    kafka_policy_query: "[? name == '{{ item.name }}'].id"
   set_fact:
-    hive_policy_id: "{{ jsoncontent.json | community.general.json_query(hive_policy_query) }}"
+    kafka_policy_id: "{{ jsoncontent.json | community.general.json_query(kafka_policy_query) }}"
 
-- name: Create Hive policy for user
+- name: Create Kafka policy for user
   uri:
-    url: "{{ ranger_hive_install_properties.POLICY_MGR_URL }}/service/public/v2/api/policy"
+    url: "{{ ranger_kafka_install_properties.POLICY_MGR_URL }}/service/public/v2/api/policy"
     headers:
       Accept: application/json
     body: "{{ item | to_json }}"
@@ -27,4 +27,4 @@
     url_password: "{{ ranger_admin_password }}"
     force_basic_auth: yes
     method: POST
-  when: not hive_policy_id
+  when: not kafka_policy_id

--- a/roles/kafka/README.md
+++ b/roles/kafka/README.md
@@ -5,7 +5,7 @@ This is the main Kafka directory. It includes the following sub-roles:
 - Kafka Broker
 - Kafka Client
 
-Currently the roles only supports the deployment of SSL-enabled, Kerberos authenticated Kafka clusters (= `SASL_SSL` listener + `GSSAPI` mechanism).
+Currently the roles only supports the deployment of SSL-enabled, Kerberos authenticated Kafka clusters (= `SASL_SSL` listener + `GSSAPI` mechanism) and the Kafka Ranger plugin is installed and enabled by default.
 
 ## Prerequisites
 
@@ -14,6 +14,7 @@ Currently the roles only supports the deployment of SSL-enabled, Kerberos authen
 - Group `kafka_broker` defined in the Ansible inventory
 - Certificate of the CA available as `root.pem` in `files`
 - Certificate files `{{ fqdn }}.key` and `{{ fqdn }}.pem` available in `files`
+- One certificate dedicated to the Kafka Ranger plugin with a Common Name equal to `ranger_kafka_service_properties.commonNameForCertificate` available in `files`
 - Admin access to a KDC with the `realm`, `kadmin_principal` and `kadmin_password` role vars provided
 
 ## Example

--- a/roles/kafka/common/templates/install_kafka.properties.j2
+++ b/roles/kafka/common/templates/install_kafka.properties.j2
@@ -1,0 +1,141 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Location of component folder
+COMPONENT_INSTALL_DIR_NAME={{ kafka_install_dir }}
+
+#
+# Location of Policy Manager URL
+#
+# Example:
+# POLICY_MGR_URL=http://policymanager.xasecure.net:6080
+#
+POLICY_MGR_URL={{ ranger_kafka_install_properties.POLICY_MGR_URL }}
+
+#
+# This is the repository name created within policy manager
+#
+# Example:
+# REPOSITORY_NAME=kafkadev
+#
+REPOSITORY_NAME={{ ranger_kafka_install_properties.REPOSITORY_NAME }}
+
+# AUDIT configuration with V3 properties
+
+#Should audit be summarized at source
+XAAUDIT.SUMMARY.ENABLE=true
+
+# Enable audit logs to Solr
+#Example
+#XAAUDIT.SOLR.ENABLE=true
+#XAAUDIT.SOLR.URL=http://localhost:6083/solr/ranger_audits
+#XAAUDIT.SOLR.ZOOKEEPER=
+#XAAUDIT.SOLR.FILE_SPOOL_DIR=/var/log/kafka/audit/solr/spool
+
+XAAUDIT.SOLR.ENABLE={{ ranger_kafka_install_properties.XAAUDIT_SOLR_ENABLE }}
+XAAUDIT.SOLR.URL={{ ranger_kafka_install_properties.XAAUDIT_SOLR_URL }}
+XAAUDIT.SOLR.USER=NONE
+XAAUDIT.SOLR.PASSWORD=NONE
+XAAUDIT.SOLR.ZOOKEEPER=NONE
+XAAUDIT.SOLR.FILE_SPOOL_DIR=/var/log/kafka/audit/solr/spool
+
+# Enable audit logs to HDFS
+#Example
+#XAAUDIT.HDFS.ENABLE=true
+#XAAUDIT.HDFS.HDFS_DIR=hdfs://node-1.example.com:8020/ranger/audit
+#  If using Azure Blob Storage
+#XAAUDIT.HDFS.HDFS_DIR=wasb[s]://<containername>@<accountname>.blob.core.windows.net/<path>
+#XAAUDIT.HDFS.HDFS_DIR=wasb://ranger_audit_container@my-azure-account.blob.core.windows.net/ranger/audit
+#XAAUDIT.HDFS.FILE_SPOOL_DIR=/var/log/kafka/audit/hdfs/spool
+
+XAAUDIT.HDFS.ENABLE={{ ranger_kafka_install_properties.XAAUDIT_HDFS_ENABLE }}
+XAAUDIT.HDFS.HDFS_DIR={{ ranger_kafka_install_properties.audit_hdfs }}/ranger/audit
+XAAUDIT.HDFS.FILE_SPOOL_DIR=/var/log/kafka/audit/hdfs/spool
+
+# Following additional propertis are needed When auditing to Azure Blob Storage via HDFS
+# Get these values from your /etc/hadoop/conf/core-site.xml
+#XAAUDIT.HDFS.HDFS_DIR=wasb[s]://<containername>@<accountname>.blob.core.windows.net/<path>
+XAAUDIT.HDFS.AZURE_ACCOUNTNAME=__REPLACE_AZURE_ACCOUNT_NAME
+XAAUDIT.HDFS.AZURE_ACCOUNTKEY=__REPLACE_AZURE_ACCOUNT_KEY
+XAAUDIT.HDFS.AZURE_SHELL_KEY_PROVIDER=__REPLACE_AZURE_SHELL_KEY_PROVIDER
+XAAUDIT.HDFS.AZURE_ACCOUNTKEY_PROVIDER=__REPLACE_AZURE_ACCOUNT_KEY_PROVIDER
+
+# End of V3 properties
+
+#
+#  Audit to HDFS Configuration
+#
+# If XAAUDIT.HDFS.IS_ENABLED is set to true, please replace tokens
+# that start with __REPLACE__ with appropriate values
+#  XAAUDIT.HDFS.IS_ENABLED=true
+#  XAAUDIT.HDFS.DESTINATION_DIRECTORY=hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%
+#  XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY=__REPLACE__LOG_DIR/kafka/audit
+#  XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY=__REPLACE__LOG_DIR/kafka/audit/archive
+#
+# Example:
+#  XAAUDIT.HDFS.IS_ENABLED=true
+#  XAAUDIT.HDFS.DESTINATION_DIRECTORY=hdfs://namenode.example.com:8020/ranger/audit/%app-type%/%time:yyyyMMdd%
+#  XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY=/var/log/kafka/audit
+#  XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY=/var/log/kafka/audit/archive
+#
+XAAUDIT.HDFS.IS_ENABLED={{ ranger_kafka_install_properties.XAAUDIT_HDFS_ENABLE }}
+XAAUDIT.HDFS.DESTINATION_DIRECTORY={{ ranger_kafka_install_properties.audit_hdfs }}/ranger/audit/%app-type%/%time:yyyyMMdd%
+XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY={{ kafka_log_dir }}/audit/%app-type%
+XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY={{ kafka_log_dir }}/audit/archive/%app-type%
+
+XAAUDIT.HDFS.DESTINTATION_FILE=%hostname%-audit.log
+XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS=900
+XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS=86400
+XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS=60
+XAAUDIT.HDFS.LOCAL_BUFFER_FILE=%time:yyyyMMdd-HHmm.ss%.log
+XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS=60
+XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS=600
+XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT=10
+
+#Solr Audit Provider
+XAAUDIT.SOLR.IS_ENABLED=false
+XAAUDIT.SOLR.MAX_QUEUE_SIZE=1
+XAAUDIT.SOLR.MAX_FLUSH_INTERVAL_MS=1000
+XAAUDIT.SOLR.SOLR_URL=http://localhost:6083/solr/ranger_audits
+
+#
+# SSL Client Certificate Information
+#
+# Example:
+# SSL_KEYSTORE_FILE_PATH=/etc/hadoop/conf/ranger-plugin-keystore.jks
+# SSL_KEYSTORE_PASSWORD=none
+# SSL_TRUSTSTORE_FILE_PATH=/etc/hadoop/conf/ranger-plugin-truststore.jks
+# SSL_TRUSTSTORE_PASSWORD=none
+#
+# You do not need use SSL between agent and security admin tool, please leave these sample value as it is.
+#
+SSL_KEYSTORE_FILE_PATH={{ ranger_kafka_keystore_location }}
+SSL_KEYSTORE_PASSWORD={{ ranger_kafka_keystore_password }}
+SSL_TRUSTSTORE_FILE_PATH={{ kafka_truststore_location }}
+SSL_TRUSTSTORE_PASSWORD={{ kafka_truststore_password }}
+
+
+#
+# Custom component user
+# CUSTOM_COMPONENT_USER=<custom-user>
+# keep blank if component user is default
+CUSTOM_USER={{ kafka_user }}
+
+
+#
+# Custom component group
+# CUSTOM_COMPONENT_GROUP=<custom-group>
+# keep blank if component group is default
+CUSTOM_GROUP={{ kafka_group }}

--- a/roles/kafka/common/templates/kafka-env.conf.j2
+++ b/roles/kafka/common/templates/kafka-env.conf.j2
@@ -1,4 +1,5 @@
 LOG_DIR="{{ kafka_log_dir }}"
+CLASSPATH="{{ kafka_broker_conf_dir }}{{ ':' + hadoop_client_conf_dir + ':' + hadoop_client_class_path if ranger_kafka_install_properties.XAAUDIT_HDFS_ENABLE == 'true' else '' }}"
 KAFKA_OPTS="-Djava.security.auth.login.config={{ kafka_broker_conf_dir }}/kafka_server_jaas.conf"
 KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:{{ kafka_broker_conf_dir }}/log4j.properties"
 KAFKA_HEAP_OPTS="{{ kafka_broker_heap_opts }}"

--- a/roles/kafka/ranger/tasks/config.yml
+++ b/roles/kafka/ranger/tasks/config.yml
@@ -1,0 +1,50 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Template install.properties
+  template:
+    src: install_kafka.properties.j2
+    dest: "{{ ranger_kafka_install_dir }}/install.properties"
+
+# enable-kakfa-plugin.sh will only modify configuration files in /opt/tdp/kafka/config
+# There is no way to tell the script to use /etc/kafka/conf.broker
+# So we create a symbolic link in installation /opt/kafka/ that points to actual conf
+- name: Backup {{ kafka_install_dir }}/config
+  command: mv {{ kafka_install_dir }}/config {{ kafka_install_dir }}/config.bk
+  args:
+    creates: "{{ kafka_install_dir }}/config.bk"
+
+- name: Create symbolic link from conf in {{ kafka_install_dir }} to actual Kafka broker conf
+  file:
+    src: "{{ kafka_broker_conf_dir }}"
+    dest: "{{ kafka_install_dir }}/config"
+    state: link
+
+- name: Run enable-kafka-plugin.sh
+  shell: |
+    export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
+    ./enable-kafka-plugin.sh
+  args:
+    chdir: "{{ ranger_kafka_install_dir }}"
+  register: enable_kafka_output
+  failed_when:
+    - "'Exiting plugin installation' in enable_kafka_output.stdout"
+
+- name: Overwrite ranger.plugin.kafka.policy.rest.ssl.config.file
+  lineinfile:
+    path: "{{ kafka_broker_conf_dir }}/ranger-kafka-security.xml"
+    regexp: "<value>/etc/kafka/conf/ranger-policymgr-ssl.xml</value>"
+    line: "\t\t<value>{{ kafka_broker_conf_dir }}/ranger-policymgr-ssl.xml</value>"
+
+# Needed for writing audits to HDFS
+- name: Set fs.hdfs.impl class to org.apache.hadoop.hdfs.DistributedFileSystem
+  blockinfile:
+    path: "{{ kafka_broker_conf_dir }}/ranger-kafka-audit.xml"
+    insertbefore: "</configuration>"
+    marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
+    block: |2
+          <property>
+              <name>xasecure.audit.destination.hdfs.config.fs.hdfs.impl</name>
+              <value>org.apache.hadoop.hdfs.DistributedFileSystem</value>
+          </property>

--- a/roles/kafka/ranger/tasks/init.yml
+++ b/roles/kafka/ranger/tasks/init.yml
@@ -1,0 +1,29 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Create Kafka service
+  run_once: true
+  uri:
+    url: "{{ ranger_kafka_install_properties.POLICY_MGR_URL }}/service/plugins/services"
+    method: POST
+    body:
+      name: "{{ ranger_kafka_install_properties.REPOSITORY_NAME }}"
+      isEnabled: true
+      configs:
+        username: kafka
+        password: kafka
+        commonNameForCertificate: "{{ ranger_kafka_service_properties.commonNameForCertificate }}"
+        policy.download.auth.users: kafka
+        zookeeper.connect: "{{ kafka_server_properties['zookeeper.connect'] }}"
+      type: kafka
+    body_format: json
+    force_basic_auth: yes
+    user: admin
+    password: "{{ ranger_admin_password }}"
+    headers:
+      Content-Type: application/json
+    status_code: [200, 400]
+    validate_certs: no
+  register: reg_kafka
+  changed_when: reg_kafka.status == 200

--- a/roles/kafka/ranger/tasks/install.yml
+++ b/roles/kafka/ranger/tasks/install.yml
@@ -1,0 +1,24 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Upload {{ ranger_kafka_dist_file }}
+  copy:
+    src: "files/{{ ranger_kafka_dist_file }}"
+    dest: /tmp
+  diff: no
+
+- name: Extract {{ ranger_kafka_dist_file }}
+  unarchive:
+    src: "/tmp/{{ ranger_kafka_dist_file }}"
+    dest: "{{ kafka_root_dir }}"
+    group: root
+    owner: root
+    remote_src: yes
+    creates: "{{ kafka_root_dir }}/{{ ranger_kafka_release }}"
+
+- name: Create symbolic link to Ranger installation
+  file:
+    src: "{{ kafka_root_dir }}/{{ ranger_kafka_release }}"
+    dest: "{{ ranger_kafka_install_dir }}"
+    state: link

--- a/roles/kafka/ranger/tasks/ssl-tls.yml
+++ b/roles/kafka/ranger/tasks/ssl-tls.yml
@@ -1,0 +1,18 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- include_role:
+    name: tosit.tdp.utils.ssl_tls
+    tasks_from: create_keystore
+  vars:
+    ansible_fqdn: "{{ ranger_kafka_service_properties.commonNameForCertificate }}"
+    keystore_location: "{{ ranger_kafka_keystore_location }}"
+    keystore_password: "{{ ranger_kafka_keystore_password }}"
+
+- include_role:
+    name: tosit.tdp.utils.ssl_tls
+    tasks_from: create_truststore
+  vars:
+    truststore_location: "{{ kafka_truststore_location }}"
+    truststore_password: "{{ kafka_truststore_password }}"

--- a/roles/kafka/ranger/templates
+++ b/roles/kafka/ranger/templates
@@ -1,0 +1,1 @@
+../common/templates

--- a/tdp_lib_dag/kafka.yml
+++ b/tdp_lib_dag/kafka.yml
@@ -17,6 +17,9 @@
   depends_on:
     - kafka_broker_install
 
+- name: kafka_ranger_install
+  depends_on: []
+
 - name: kafka_jmx-exporter_config
   depends_on:
     - exporter_jmx_install
@@ -31,9 +34,23 @@
   depends_on:
     - kafka_kerberos_install
 
+- name: kafka_ranger_config
+  depends_on:
+    - kafka_ranger_install
+    - kafka_broker_config
+
+- name: kafka_ranger_ssl-tls_install
+  depends_on: []
+
+- name: kafka_ranger_init
+  depends_on:
+    - ranger_admin_init
+    - kafka_ranger_config
+
 - name: kafka_broker_start
   depends_on:
     - zookeeper-kafka_init
+    - kafka_ranger_init
     - kafka_broker_config
     - kafka_jmx-exporter_config
 
@@ -44,6 +61,8 @@
     - kafka_client_install
     - kafka_kerberos_install
     - kafka_ssl-tls_install
+    - kafka_ranger_install
+    - kafka_ranger_ssl-tls_install
 
 - name: kafka_config
   noop: yes
@@ -52,6 +71,7 @@
     - kafka_broker_config
     - kafka_client_config
     - kafka_jmx-exporter_config
+    - kafka_ranger_config
 
 - name: kafka_start
   noop: yes

--- a/tdp_vars_defaults/kafka/kafka.yml
+++ b/tdp_vars_defaults/kafka/kafka.yml
@@ -64,6 +64,8 @@ kafka_server_properties:
   ssl.keystore.password: "{{ kafka_keystore_password }}"
   ssl.truststore.location: "{{ kafka_truststore_location }}"
   ssl.truststore.password: "{{ kafka_truststore_password }}"
+  # Ranger
+  authorizer.class.name: org.apache.ranger.authorization.kafka.authorizer.RangerKafkaAuthorizer
   # Socket Server Settings
   num.network.threads: 3
   num.io.threads: 8
@@ -83,7 +85,7 @@ kafka_server_properties:
   log.retention.check.interval.ms: 300000
   # ZooKeeper
   zookeeper.connect: "{{ zookeeper_client_quorum }}/kafka"
-  zookeeper.connection.timeout.ms: 18000
+  zookeeper.connection.timeout.ms: 60000
   zookeeper.set.acl: "true"
   # Group Coordinator Settings
   group.initial.rebalance.delay.ms: 3
@@ -105,6 +107,36 @@ kafka_consumer_properties: {}
 
 # Service restart policies
 kafka_restart: "no"
+
+# Hadoop client directories (used if XAAUDIT_HDFS_ENABLE is true)
+hadoop_install_dir: "/opt/tdp/hadoop"
+hadoop_client_conf_dir: "/etc/hadoop/conf"
+hadoop_client_missing_jars:
+  - "{{ hadoop_install_dir }}/share/hadoop/common/hadoop-common-3.1.1-TDP-0.1.0-SNAPSHOT.jar"
+  - "{{ hadoop_install_dir }}/share/hadoop/hdfs/hadoop-hdfs-client-3.1.1-TDP-0.1.0-SNAPSHOT.jar"
+  - "{{ hadoop_install_dir }}/share/hadoop/hdfs/lib/commons-logging-1.1.3.jar"
+  - "{{ hadoop_install_dir }}/share/hadoop/hdfs/lib/woodstox-core-5.0.3.jar"
+  - "{{ hadoop_install_dir }}/share/hadoop/hdfs/lib/stax2-api-3.1.4.jar"
+  - "{{ hadoop_install_dir }}/share/hadoop/hdfs/lib/guava-11.0.2.jar"
+  - "{{ hadoop_install_dir }}/share/hadoop/hdfs/lib/commons-collections-3.2.2.jar"
+hadoop_client_class_path: "{{ hadoop_client_missing_jars | join(':') }}"
+
+# Ranger Kafka properties
+ranger_kafka_release: ranger-2.0.1-TDP-0.1.0-SNAPSHOT-kafka-plugin
+ranger_kafka_dist_file: "{{ ranger_kafka_release }}.tar.gz"
+ranger_kafka_install_dir: "{{ kafka_root_dir }}/ranger-kafka-plugin"
+ranger_kafka_install_properties:
+  POLICY_MGR_URL: "https://{{ groups['ranger_admin'][0] | tosit.tdp.access_fqdn(hostvars) }}:6182"
+  REPOSITORY_NAME: kafka-tdp
+  XAAUDIT_SOLR_ENABLE: "{% if 'ranger_solr' in groups and groups['ranger_solr'] %}true{% else %}false{% endif %}"
+  XAAUDIT_SOLR_URL: "{% if 'ranger_solr' in groups and groups['ranger_solr'] %}http://{{ groups['ranger_solr'][0] | tosit.tdp.access_fqdn(hostvars) }}:8983/solr/ranger_audits{% else %}NONE{% endif %}"
+  # HDFS audits disabled because not functional
+  XAAUDIT_HDFS_ENABLE: "false"
+  audit_hdfs: hdfs://mycluster
+ranger_kafka_keystore_location: /etc/ssl/certs/ranger-kafka-plugin-keystore.jks
+ranger_kafka_keystore_password: Keystore123!
+ranger_kafka_service_properties:
+  commonNameForCertificate: "ranger-kafka-plugin.{{ domain }}"
 
 # JMX Exporter configuration directory
 jmx_exporter_conf_dir: /etc/jmx-exporter


### PR DESCRIPTION
Fixes #42 

Depends on:
- #40 

This PR adds the `kafka.ranger` role.

**Notes:**
- The plugin relies on an extra SSL certificate to communicate with Ranger (we have to do this because all brokers have to use the same Common Name when connecting to Ranger Admin)
- The writing of audits to HDFS is not operational, I am gonna create an issue to fix this in a later PR.