### PR TITLE
fix: add zk_kafka group to hosts template

### DIFF
--- a/roles/ansible-tdp-common-actions/templates/ansible-hosts.j2
+++ b/roles/ansible-tdp-common-actions/templates/ansible-hosts.j2
@@ -11,6 +11,9 @@ edge-01
 [zk]
 master-0[1:3]
 
+[zk_kafka]
+master-0[1:3]
+
 [zk_client]
 edge-01
 


### PR DESCRIPTION
Fix #46 