### PR TITLE
jupyterhub: make hdfs venv configurable per user 

### DIFF
--- a/roles/jupyterhub/server/tasks/hdfs-init.yml
+++ b/roles/jupyterhub/server/tasks/hdfs-init.yml
@@ -17,7 +17,7 @@
   become: true
   become_user: "{{ hdfs_user }}"
   loop:
-    - path: /jupyterhub/virtualenvs
+    - path: "{{ jupyterhub_hdfs_venvs_dir }}"
       state: directory
       owner: "{{ jupyterhub_user }}"
       group: "{{ jupyterhub_group }}"

--- a/roles/jupyterhub/server/tasks/init.yml
+++ b/roles/jupyterhub/server/tasks/init.yml
@@ -15,7 +15,7 @@
     {{ hadoop_install_dir }}/bin/hdfs
     --config {{ hadoop_client_conf_dir }}
     dfs
-    -put {{ jupyterhub_install_dir }}/share/yarn_environment.tar.gz {{ jupyterhub_properties['yarnspawner']['localize_files']['environment']['source'] }}
+    -put {{ jupyterhub_install_dir }}/share/yarn_environment.tar.gz {{ jupyterhub_hdfs_venvs_dir }}
   become: true
   become_user: "{{ jupyterhub_user }}"
   register: hdfs_put_venv

--- a/roles/jupyterhub/server/templates/jupyterhub_config.py.j2
+++ b/roles/jupyterhub/server/templates/jupyterhub_config.py.j2
@@ -106,6 +106,7 @@ def pre_spawn_hook(spawner):
     # spawner.user_options holds the value parsed from the form
     # values are always list of strings
     queue = spawner.user_options.get("queue", ["default"])[0]
+    venv = spawner.user_options.get("venv", ["yarn_environment"])[0]
     cpu_limit = spawner.user_options.get("cpu", ["1"])[0]
     mem_limit = spawner.user_options.get("memory", ["2G"])[0]
     mem_limit = int(mem_limit) if mem_limit.isnumeric() else mem_limit
@@ -126,6 +127,7 @@ def pre_spawn_hook(spawner):
     spawner.cpu_limit = cpu_limit
     spawner.mem_limit = mem_limit
     spawner.queue = queue
+    spawner.localize_files = { 'environment': { 'source': ("hdfs://{{ jupyterhub_hdfs_venvs_dir }}/" + venv +".tar.gz") } }
 
 {% for key, value in jupyterhub_properties.get('yarnspawner', {}).items() +%}
 c.YarnSpawner.{{ key }} = {% if value is string and not value.startswith('f:') %}'{{ value }}'{% else %}{{ value if value is not string else value.lstrip('f:') }}{% endif %}

--- a/tdp_vars_defaults/jupyterhub/jupyterhub.yml
+++ b/tdp_vars_defaults/jupyterhub/jupyterhub.yml
@@ -37,6 +37,9 @@ jupyterhub_log_dir: /var/log/jupyterhub
 # Jupyterhub working directory
 jupyterhub_working_dir: /var/lib/jupyterhub
 
+# Jupyterhub HDFS venvs dir
+jupyterhub_hdfs_venvs_dir: /jupyterhub/virtualenvs
+
 # Jupyterhub configuration
 jupyterhub_port: 8000
 
@@ -80,14 +83,13 @@ jupyterhub_properties:
     default_url: /lab
     # environment:
     keytab: /etc/security/keytabs/jupyterhub.service.keytab
-    localize_files:
-      environment:
-        source: hdfs:///jupyterhub/virtualenvs/yarn_environment.tar.gz
     mem_limit: 8G
     cpu_limit: 2
     options_form: |-
       f:"""<label for="queue">Queue name:&nbsp;</label>
       <input name="queue" type="text" value="default" required /><br />
+      <label for="venv">Venv Name:&nbsp;</label>
+      <input name="venv" type="text" value="yarn_environment" required /><br />      
       <label for="cpu">Instance Cpu:&nbsp;</label>
       <input name="cpu" type="number" min="1" step="1" value="1" required /><br />
       <label for="memory">Instance Memory:&nbsp;</label>


### PR DESCRIPTION
Make hdfs venv configurable per user from jupyterhub form

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #131 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
