### PR TITLE
hue: add execute permission to stop-hue-server.sh

### DIFF
--- a/roles/hue/server/tasks/install.yml
+++ b/roles/hue/server/tasks/install.yml
@@ -117,7 +117,7 @@
     dest: "{{ hue_install_dir }}/build/env/bin/stop-hue-server.sh"
     owner: root
     group: root
-    mode: "644"
+    mode: "755"
 
 - name: Template Hue service file
   ansible.builtin.template:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #137

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

We need to change the script ```stop-hue-server.sh``` permission to 755, to avoid ```failed``` error with ```systemctl status hue``` after restarting or stopping the service. 

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
