### PR TITLE
fix: undefined variable in tdp_cluster

### DIFF
--- a/tdp_vars_defaults/tdp-cluster/tdp-cluster.yml
+++ b/tdp_vars_defaults/tdp-cluster/tdp-cluster.yml
@@ -60,7 +60,7 @@ observability_tdp_targets:
   livy:
     labels:
       type: tdp_core
-      svc_dashboard: "{{ dashboard_without_workers }}"
+      svc_dashboard: "{{ dashboard_without_workers | default('') }}"
     server:
       jobs:
         - log_file: "{{ livy_spark_log_dir }}/{{ livy_spark_log_file }}"
@@ -69,7 +69,7 @@ observability_tdp_targets:
   livy_spark3:
     labels:
       type: tdp_core
-      svc_dashboard: "{{ dashboard_without_workers }}"
+      svc_dashboard: "{{ dashboard_without_workers | default('') }}"
     server:
       jobs:
         - log_file: "{{ livy_spark3_log_dir }}/{{ livy_spark3_log_file }}"
@@ -78,7 +78,7 @@ observability_tdp_targets:
   jupyterhub:
     labels:
       type: tdp_core
-      svc_dashboard: "{{ dashboard_python }}"
+      svc_dashboard: "{{ dashboard_python | default('') }}"
     server:
       jobs:
         - log_file: "{{ jupyterhub_log_dir }}/{{ jupyterhub_log_file }}"
@@ -91,7 +91,7 @@ observability_tdp_targets:
   hue:
     labels:
       type: tdp_core
-      svc_dashboard: "{{ dashboard_python }}"
+      svc_dashboard: "{{ dashboard_python | default('') }}"
     server:
       jobs:
         - log_file: "{{ hue_log_dir }}/{{ hue_promtail_collected_log }}"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Comments

When `tdp_observability` is not installed, some variables referenced in `tdp_extra/tdp_vars_default/tdp_cluster/tdp_cluster.yml` are missing.

This fix addresses that issue by protecting them with a `| default('')`


#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
