### PR TITLE
fix: hue install failed when postgresql group missing

### DIFF
--- a/roles/hue/server/templates/hue.ini.j2
+++ b/roles/hue/server/templates/hue.ini.j2
@@ -666,12 +666,9 @@ user_name_attr={{ ldapauth.users.user_name_attr }}
 # Note for Oracle, options={"threaded":true} must be set in order to avoid crashes.
 # Note for Oracle, you can use the Oracle Service Name by setting "host=" and "port=" and then "name=<host>:<port>/<service_name>".
 # Note for MariaDB use the 'mysql' engine.
-engine={{ database.engine }}
-host={{ database.host }}
-port={{ database.port }}
-user={{ database.user }}
-password={{ database.password }}
-name={{ database.name }}
+{% for key, value in database.items() %}
+{{ key }}={{ value }}
+{% endfor %}
 # conn_max_age option to make database connection persistent value in seconds
 # https://docs.djangoproject.com/en/1.11/ref/databases/#persistent-connections
 ## conn_max_age=0
@@ -1038,7 +1035,7 @@ show_notebooks=true
 #[[[postgresql]]]
 #  name = postgresql
 #  interface=sqlalchemy
-#  options='{"url": "postgresql://hue:hue@{{ groups['postgresql'][0] }}:5432/hue"}'
+#  options='{"url": "postgresql://hue:hue@pgserver:5432/hue"}'
 
 # [[[druid]]]
 #   name = Druid

--- a/tdp_vars_defaults/hue/hue.yml
+++ b/tdp_vars_defaults/hue/hue.yml
@@ -81,7 +81,7 @@ oidcauth:
   oidc_username_attribute: preferred_username
 database:
   engine: "postgresql_psycopg2"
-  host: "{{ groups['postgresql'][0] | tosit.tdp.access_fqdn(hostvars) }}"
+  host: "{{ groups['postgresql'][0] | default('localhost') | tosit.tdp.access_fqdn(hostvars) }}"
   port: "{{ postgresql_server_port }}"
   user: "{{ db_hue_user }}"
   password: "{{ db_hue_password }}"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Additional comments

Hue configuration fails when postgreql group is absent from ansible inventory.
This is due to a reference to `groups['postgresql']` in hue.ini.j2

Fixed by adding a default filter. Besides, we configure a sqlite3 engine by default.


#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
