### PR TITLE
Add daemon reload handlers in all services

### DIFF
--- a/roles/airflow/handlers
+++ b/roles/airflow/handlers
@@ -1,0 +1,1 @@
+../common/handlers/

--- a/roles/airflow/tasks/executor.yaml
+++ b/roles/airflow/tasks/executor.yaml
@@ -14,3 +14,4 @@
   ansible.builtin.template:
     src: airflow-flower.service.j2
     dest: /usr/lib/systemd/system/airflow-flower.service
+  notify: systemctl daemon-reload

--- a/roles/airflow/tasks/scheduler.yaml
+++ b/roles/airflow/tasks/scheduler.yaml
@@ -3,3 +3,4 @@
   ansible.builtin.template:
     src: airflow-scheduler.service.j2
     dest: /usr/lib/systemd/system/airflow-scheduler.service
+  notify: systemctl daemon-reload

--- a/roles/airflow/tasks/webserver.yaml
+++ b/roles/airflow/tasks/webserver.yaml
@@ -25,3 +25,4 @@
   ansible.builtin.template:
     src: airflow-webserver.service.j2
     dest: /usr/lib/systemd/system/airflow-webserver.service
+  notify: systemctl daemon-reload

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: reload systemd
+- name: systemctl daemon-reload
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/hue/server/handlers
+++ b/roles/hue/server/handlers
@@ -1,0 +1,1 @@
+../../common/handlers/

--- a/roles/hue/server/tasks/install.yml
+++ b/roles/hue/server/tasks/install.yml
@@ -135,3 +135,4 @@
     owner: root
     group: root
     mode: "644"
+  notify: systemctl daemon-reload

--- a/roles/jupyterhub/server/handlers
+++ b/roles/jupyterhub/server/handlers
@@ -1,0 +1,1 @@
+../../common/handlers/

--- a/roles/jupyterhub/server/tasks/config.yml
+++ b/roles/jupyterhub/server/tasks/config.yml
@@ -20,7 +20,7 @@
     owner: root
     group: root
     mode: "0644"
-  notify: reload systemd
+  notify: systemctl daemon-reload
 
 - name: Template jupyterhub_start.sh
   ansible.builtin.template:

--- a/roles/kafka/broker/handlers
+++ b/roles/kafka/broker/handlers
@@ -1,0 +1,1 @@
+../../common/handlers/

--- a/roles/kafka/broker/tasks/install.yml
+++ b/roles/kafka/broker/tasks/install.yml
@@ -30,3 +30,4 @@
     owner: root
     group: root
     mode: "644"
+  notify: systemctl daemon-reload

--- a/roles/livy/server/handlers
+++ b/roles/livy/server/handlers
@@ -1,0 +1,1 @@
+../../common/handlers/

--- a/roles/livy/server/tasks/install.yml
+++ b/roles/livy/server/tasks/install.yml
@@ -69,3 +69,4 @@
     owner: root
     group: root
     mode: "644"
+  notify: systemctl daemon-reload


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

No handlers were present in the collection (except in jupyterhub). A systemctl daemon-reload should be used after each modification of systemd's service file. The same architecture as tdp-collection of having a common set of handlers is used in this PR

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
