### PR TITLE
feat(jupyter): add "jupyter_lab" ansible group

### DIFF
--- a/playbooks/jupyter_lab_config.yml
+++ b/playbooks/jupyter_lab_config.yml
@@ -3,7 +3,7 @@
 
 ---
 - name: Configure Jupyterlab
-  hosts: yarn_nm
+  hosts: jupyter_lab
   tasks:
     - tosit.tdp.resolve: # noqa unnamed-task
         node_name: jupyter_lab

--- a/playbooks/jupyter_lab_install.yml
+++ b/playbooks/jupyter_lab_install.yml
@@ -3,7 +3,7 @@
 
 ---
 - name: Install Jupyterlab
-  hosts: yarn_nm
+  hosts: jupyter_lab
   tasks:
     - tosit.tdp.resolve: # noqa unnamed-task
         node_name: jupyter_lab

--- a/topology.ini
+++ b/topology.ini
@@ -29,6 +29,10 @@ master3
 [hadoop_client:children]
 jupyter_hub
 
+# jupyterlab need to be installed on yarn_nm
+[jupyter_lab:children]
+yarn_nm
+
 # pyspark3 kernel requires yarn_nm to be spark3_client
 [spark3_client:children]
 yarn_nm


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Using the Ansible group "yarn_nm" forced the installation of JupyterLab as soon as the extra collection was enabled while it is the topology that should determine if JupyterLab should be installed. This is why adding an Ansible group "jupyter_lab" makes the installation of JupyterLab optional.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
