### PR TITLE
Stephan/feat/hue firewall

### DIFF
--- a/tdp_vars_defaults/firewall/firewall.yml
+++ b/tdp_vars_defaults/firewall/firewall.yml
@@ -847,8 +847,8 @@ firewalld_rules:
       - internal
       state: present
 
-  # Livy
-  livy:
+  # Livy for Spark2
+  livy_server:
     - name: livy_spark2_server_port
       short: livy spark2 - HTTP port - livy.server.port
       port: "{{ livy_spark2_server_port }}"
@@ -857,6 +857,9 @@ firewalld_rules:
         - internal
         - public
       state: present
+
+  # Livy for Spark3
+  livy_spark3_server:
     - name: livy_spark3_server_port
       short: livy spark3 - HTTP port - livy.server.port
       port: "{{ livy_spark3_server_port }}"

--- a/tdp_vars_defaults/firewall/firewall.yml
+++ b/tdp_vars_defaults/firewall/firewall.yml
@@ -857,6 +857,15 @@ firewalld_rules:
         - internal
         - public
       state: present
+    # Prometheus exporter
+    - name: exporter_livy_spark_http_port
+      short: livy spark2 - Prometheus exporter HTTP port - ?
+      port: "{{ exporter_livy_spark_http_port }}"
+      protocol: tcp
+      zones:
+        - internal
+        - public
+      state: present
 
   # Livy for Spark3
   livy_spark3_server:
@@ -867,4 +876,13 @@ firewalld_rules:
       zones:
       - internal
       - public
+      state: present
+      # Prometheus exporter
+    - name: exporter_livy_spark3_http_port
+      short: livy spark3 - Prometheus exporter HTTP port - ?
+      port: "{{ exporter_livy_spark3_http_port }}"
+      protocol: tcp
+      zones:
+        - internal
+        - public
       state: present

--- a/tdp_vars_defaults/firewall/firewall.yml
+++ b/tdp_vars_defaults/firewall/firewall.yml
@@ -818,6 +818,17 @@ firewalld_rules:
         - public
       state: present
 
+  # Hue
+  hue_server:
+    - name: hue_web_http_port
+      short: Hue - HTTP port - bind_url_port
+      port: "{{ hue_web_http_port }}"
+      protocol: tcp
+      zones:
+        - internal
+        - public
+      state: present
+
   # Jupyter
   jupyter_hub:
     - name: jupyterhub_http_port


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

- Added Hue in the firewall rules so that its web port is open.
- Fixed syntax for the rule of Livy Server Spark2 and Livy Server Spark3.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
