### PR TITLE
211 'virtualenv': command not found on most recent RHEL

### DIFF
--- a/roles/jupyter/lab/tasks/install.yml
+++ b/roles/jupyter/lab/tasks/install.yml
@@ -69,6 +69,7 @@
     umask: "0022"
     virtualenv: "{{ jupyterlab_root_dir }}/{{ jupyterlab_release }}"
     virtualenv_python: "{{ jupyterlab_python_executable }}"
+    virtualenv_command: "{{ jupyterlab_virtualenv_command }}"
 
 - name: Install Jupyterlab in virtual env
   ansible.builtin.pip:

--- a/tdp_vars_defaults/jupyter/jupyter.yml
+++ b/tdp_vars_defaults/jupyter/jupyter.yml
@@ -161,6 +161,7 @@ jupyterlab_dist_file: "{{ jupyterlab_release }}.tar.gz"
 jupyterlab_upload_directory: "{{ binaries_upload_dir }}"
 
 jupyterlab_python_executable: "python3.6"
+jupyterlab_virtualenv_command: "virtualenv"
 
 # Jupyterlab installation directory
 jupyterlab_root_dir: "{{ tdp_extra_root_dir }}"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #211 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

In my most recent RHEL 8.10 install, `virtualenv` binary was not found and instead only `virtualenv-3.6` was found. This probably reflects a new behaviour of the `python3-virtualenv` package.

The PR enables a way to override virtualenv binary to use but keep the default value of virtualenv.

Associated Ansible doc: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pip_module.html

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions. 