### PR TITLE
fix: remove virtualenv_python as it duplicates with virtualenv_command

### DIFF
--- a/roles/jupyter/lab/tasks/install.yml
+++ b/roles/jupyter/lab/tasks/install.yml
@@ -68,7 +68,6 @@
     extra_args: "--no-index --find-links=file://{{ jupyterlab_root_dir }}/{{ jupyterlab_release }}/dependencies"
     umask: "0022"
     virtualenv: "{{ jupyterlab_root_dir }}/{{ jupyterlab_release }}"
-    virtualenv_python: "{{ jupyterlab_python_executable }}"
     virtualenv_command: "{{ jupyterlab_virtualenv_command }}"
 
 - name: Install Jupyterlab in virtual env
@@ -85,4 +84,3 @@
       {% endfor %}
     umask: "0022"
     virtualenv: "{{ jupyterlab_root_dir }}/{{ jupyterlab_release }}"
-    virtualenv_python: "{{ jupyterlab_python_executable }}"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fix bug introduced by #211 

When creating the virtualenv, ansible does not know which python to run and raises issue.

```
  msg: virtualenv_python should not be used when using the venv module or pyvenv as virtualenv_command
```

The fix remove virtualenv_python. It removes duplication of python version definition.

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
