### PR TITLE
feat(hue): put Hue in HA mode on master1

### DIFF
--- a/topology.ini
+++ b/topology.ini
@@ -32,6 +32,7 @@ yarn_nm
 yarn_nm
 
 [hue_server:children]
+master1
 edge
 
 # Section Postgresql_client from tdp_prerequisites


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #223


#### Additional comments

Followed the [Cloudera instructions](https://docs.cloudera.com/runtime/7.3.1/tuning-hue/topics/hue-configure-high-availability.html)

Tested by running a query and switching off the used Hue server. The result of the query disappears when it switches to the second Hue server but the query history remains.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
