### PR TITLE
refactor(hue): set log level to ERROR for errorlog handler

### DIFF
--- a/roles/hue/server/templates/log.conf.j2
+++ b/roles/hue/server/templates/log.conf.j2
@@ -74,7 +74,7 @@ args=('%LOG_DIR%/{{ hue_log_error_file }}', 'a', {{ hue_log_rfa_maxfilesize_mb *
 class=handlers.TimedRotatingFileHandler
 args=('%LOG_DIR%/{{ hue_log_error_file }}', '{{ hue_log_drfa_date_pattern  }}', 1, {{ hue_log_drfa_maxbackupindex }})
 {% endif %}
-level={{ hue_loggers_level }}
+level=ERROR
 formatter=default
 
 [formatter_default]


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

Set errorlog handler log level to Error as it is in [Hue default source code](https://github.com/TOSIT-IO/hue/blob/branch-4.10.0-TDP/desktop/conf/log.conf#L64). We therefore only have the error logs of the `hue_server_runcpserver`  logs.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [ ] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
