### PR TITLE
fix: hide passwords in ansible logs

### DIFF
--- a/roles/hue/server/tasks/config.yml
+++ b/roles/hue/server/tasks/config.yml
@@ -27,6 +27,7 @@
   vars:
     hue_user_id: "{{ hue_user_id_output.stdout | trim }}"
     livy_port: "{{ livy_server_port }}"
+  no_log: "{{ tdp_no_log is not defined or tdp_no_log }}"
 
 - name: Template Hue log configuration
   ansible.builtin.template:

--- a/roles/jupyter/hub/tasks/config.yml
+++ b/roles/jupyter/hub/tasks/config.yml
@@ -37,3 +37,4 @@
     owner: root
     group: root
     mode: "0644"
+  no_log: "{{ tdp_no_log is not defined or tdp_no_log }}"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

Some passwords are displayed in ansible logs.
This PR adds a 'no_log' parameters to such ansible tasks. It can be overridden by setting tdp_no_log variable to true

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
