### PR TITLE
refactor(topology): set edge1 node for livy-server as it cannot be in HA

### DIFF
--- a/topology-light.ini
+++ b/topology-light.ini
@@ -1,5 +1,5 @@
 [livy_spark3_server:children]
-edge
+edge1
 
 [jupyter_hub:children]
 master3

--- a/topology.ini
+++ b/topology.ini
@@ -1,5 +1,5 @@
 [livy_spark3_server:children]
-edge
+edge1
 
 [jupyter_hub:children]
 master1


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

The livy server will not work if duplicated and point to the same Zookeeper repository. Thereofre, to be able to duplicate the edge Node, the livy server has to be limited to one.

The other option is to set different Zookeeper repositories for each livy server as done in PR #184, however, they will be independant with no possibility of session recovery from one livy-server to another and seperate knox service should be implemented as well for the ui in this case.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
