### PR TITLE
fix(hue): add run_once for the database initialisation in hue_server_…

### DIFF
--- a/roles/hue/server/tasks/config.yml
+++ b/roles/hue/server/tasks/config.yml
@@ -38,6 +38,7 @@
     mode: "0644"
 
 - name: Initiate Hue database
+  run_once: true
   ansible.builtin.command: |
     {{ hue_install_dir }}/build/env/bin/hue migrate
   register: hue_database_migrate


### PR DESCRIPTION
…config

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

Corrects the error that is thrown when two hue servers are deployed at the same time at the database initialisation task.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
