### PR TITLE
fix(dag): add missing tdp-cluster_config dependency

### DIFF
--- a/tdp_lib_dag/hue.yml
+++ b/tdp_lib_dag/hue.yml
@@ -12,6 +12,7 @@
 
 - name: hue_server_config
   depends_on:
+    - tdp-cluster_config
     - hue_kerberos_install
     - hue_ssl-tls_install
 

--- a/tdp_lib_dag/jupyter.yml
+++ b/tdp_lib_dag/jupyter.yml
@@ -10,12 +10,14 @@
 
 - name: jupyter_hub_config
   depends_on:
+    - tdp-cluster_config
     - jupyter_hub_install
     - jupyter_kerberos_install
     - jupyter_ssl-tls_install
 
 - name: jupyter_lab_config
   depends_on:
+    - tdp-cluster_config
     - jupyter_lab_install
 
 - name: jupyter_hub_start

--- a/tdp_lib_dag/livy-spark3.yml
+++ b/tdp_lib_dag/livy-spark3.yml
@@ -13,11 +13,13 @@
 
 - name: livy-spark3_server_config
   depends_on:
+    - tdp-cluster_config
     - livy-spark3_kerberos_install
     - livy-spark3_ssl-tls_install
 
 - name: livy-spark3_jmx-exporter_config
   depends_on:
+    - tdp-cluster_config
     - exporter_jmx_install
     - livy-spark3_ssl-tls_install
     - livy-spark3_server_install


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Step to reproduce the problem :

1. Deploy a cluster with Hue, JupyterHub/Lab and Livy Spark 3
2. Modify `tdp_vars/tdp-cluster/tdp-cluster.yml` via `tdp vars update`
3. Run `tdp plan reconfigure`
4. Look at the plan with `tdp browse --plan`
5. `hue_server_config`, `jupyter_hub_config`, `jupyter_lab_config`, `livy-spark3_jmx-exporter_config` and `livy-spark3_server_config` are missing (this PR fix it and there are now present)

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
